### PR TITLE
Skip plotXY() unit test if hexbin isn't installed 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     covr,
     rhdf5 (>= 2.20.2),
     ggplot2,
+    hexbin,
     knitr,
     visNetwork,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: antaresViz
 Type: Package
 Title: Antares Visualizations
-Version: 0.15.3
+Version: 0.15.4
 Authors@R: c(
     person("Veronique", "Bachelier", email = "veronique.bachelier@rte-france.com", role = c("aut", "cre")),
     person("Jalal-Edine", "Zawam", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 Copyright © 2016 RTE Réseau de transport d’électricité
 
+# antaresViz 0.15.4
+
+* Fixed tests failing on CRAN
+
 # antaresViz 0.15.3 (2020-11-12)
 
 * Fixed tests failing on CRAN.

--- a/tests/testthat/test-plotXY.R
+++ b/tests/testthat/test-plotXY.R
@@ -1,6 +1,7 @@
 context("prodStack no interactive")
 
 test_that("prodStack, no interactive", {
+  skip_if_not_installed("hexbin")
   if(.requireRhdf5_Antares(stopP = FALSE)){
     dta <- readAntares(areas = "all", showProgress = FALSE)
     g <- plotXY(dta, "NODU", "LOAD", precision = 50, sizeOnCount = FALSE)


### PR DESCRIPTION
Hi @pvictor, this unit test currently assumes hexbin is installed via plotly's imports, but plotly 4.9.3 (which was submitted to CRAN last week) will be moving hexbin from Imports to Suggests. I'd be greatly appreciated if you could submit a new version to CRAN with this patch fix.